### PR TITLE
Add classical sugar keywords

### DIFF
--- a/syntaxes/fstar.tmLanguage.json
+++ b/syntaxes/fstar.tmLanguage.json
@@ -51,7 +51,7 @@
 					"name": "constant.language.fstar"
 				},
 				{
-					"match": "\\b(let|in|type|kind|val|rec|and|if|then|else|assume|admit|assert|assert_norm|squash|failwith|SMTPat|SMTPatOr|hasEq|fun|function|forall|exists|exception|by|new_effect|reify|try|synth|with|when)\\b",
+					"match": "\\b(let|in|type|kind|val|rec|and|if|then|else|assume|admit|assert|assert_norm|squash|failwith|SMTPat|SMTPatOr|hasEq|fun|function|forall|exists|exception|by|new_effect|reify|try|synth|with|when|introduce|eliminate|returns)\\b",
 					"name": "keyword.other.fstar"
 				},
 				{


### PR DESCRIPTION
Adds additional keywords used in the classical syntactic sugar (https://github.com/FStarLang/FStar/wiki/Sugar-for-manipulating-connectives-in-classical-logic#excluded-middle)

(I still use this syntax highlighting file (without modifications) along side https://github.com/FStarLang/fstar-vscode-assistant/tree/main )